### PR TITLE
[KIRIN] [Q-MR1] Fix camera configuration

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -35,6 +35,7 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/camera/camera_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/camera_config.xml \
     $(DEVICE_PATH)/vendor/etc/camera/s5k3l6_chromatix.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/s5k3l6_chromatix.xml \
+    $(DEVICE_PATH)/vendor/etc/camera/s5k4e8_chromatix.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/s5k4e8_chromatix.xml \
     $(DEVICE_PATH)/vendor/etc/camera/s5k4h7yx_chromatix.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/s5k4h7yx_chromatix.xml
 
 # Audio Configuration

--- a/rootdir/vendor/etc/camera/camera_config.xml
+++ b/rootdir/vendor/etc/camera/camera_config.xml
@@ -5,6 +5,7 @@
     <ActuatorName>lc898214xd</ActuatorName>
     <FlashName>pmic</FlashName>
     <ChromatixName>s5k3l6_chromatix</ChromatixName>
+    <I2CFrequencyMode>FAST_PLUS</I2CFrequencyMode>
     <ModesSupported>1</ModesSupported>
     <Position>BACK</Position>
     <MountAngle>90</MountAngle>
@@ -28,6 +29,7 @@
     <SensorName>s5k4e8</SensorName>
     <FlashName>pmic</FlashName>
     <ChromatixName>s5k4e8_chromatix</ChromatixName>
+    <I2CFrequencyMode>FAST_PLUS</I2CFrequencyMode>
     <ModesSupported>1</ModesSupported>
     <Position>BACK_AUX</Position>
     <MountAngle>90</MountAngle>
@@ -50,6 +52,7 @@
     <CameraId>2</CameraId>
     <SensorName>s5k4h7yx</SensorName>
     <ChromatixName>s5k4h7yx_chromatix</ChromatixName>
+    <I2CFrequencyMode>FAST_PLUS</I2CFrequencyMode>
     <ModesSupported>1</ModesSupported>
     <Position>FRONT</Position>
     <MountAngle>270</MountAngle>

--- a/rootdir/vendor/etc/camera/camera_config.xml
+++ b/rootdir/vendor/etc/camera/camera_config.xml
@@ -24,6 +24,29 @@
     </LensInfo>
   </CameraModuleConfig>
   <CameraModuleConfig>
+    <CameraId>1</CameraId>
+    <SensorName>s5k4e8</SensorName>
+    <FlashName>pmic</FlashName>
+    <ChromatixName>s5k4e8_chromatix</ChromatixName>
+    <ModesSupported>1</ModesSupported>
+    <Position>BACK_AUX</Position>
+    <MountAngle>90</MountAngle>
+    <CSIInfo>
+      <CSIDCore>2</CSIDCore>
+      <LaneMask>0x7</LaneMask>
+      <LaneAssign>0x4320</LaneAssign>
+      <ComboMode>0</ComboMode>
+    </CSIInfo>
+    <LensInfo>
+      <FocalLength>2.34</FocalLength>
+      <FNumber>2.4</FNumber>
+      <TotalFocusDistance>1.89</TotalFocusDistance>
+      <HorizontalViewAngle>75.3</HorizontalViewAngle>
+      <VerticalViewAngle>59.8</VerticalViewAngle>
+      <MinFocusDistance>0.35</MinFocusDistance>
+    </LensInfo>
+  </CameraModuleConfig>
+  <CameraModuleConfig>
     <CameraId>2</CameraId>
     <SensorName>s5k4h7yx</SensorName>
     <ChromatixName>s5k4h7yx_chromatix</ChromatixName>

--- a/rootdir/vendor/etc/camera/camera_config.xml
+++ b/rootdir/vendor/etc/camera/camera_config.xml
@@ -31,7 +31,7 @@
     <ChromatixName>s5k4e8_chromatix</ChromatixName>
     <I2CFrequencyMode>FAST_PLUS</I2CFrequencyMode>
     <ModesSupported>1</ModesSupported>
-    <Position>BACK_AUX</Position>
+    <Position>BACK</Position>
     <MountAngle>90</MountAngle>
     <CSIInfo>
       <CSIDCore>2</CSIDCore>

--- a/rootdir/vendor/etc/camera/s5k4e8_chromatix.xml
+++ b/rootdir/vendor/etc/camera/s5k4e8_chromatix.xml
@@ -1,0 +1,21 @@
+<ChromatixConfigurationRoot>
+  <CommonChromatixInfo>
+    <ChromatixName special_mode_mask="0">
+      <ISPCommon>s5k4e8_common</ISPCommon>
+      <PostProc>s5k4e8_postproc</PostProc>
+    </ChromatixName>
+  </CommonChromatixInfo>
+  <ResolutionChromatixInfo>
+    <ChromatixName sensor_resolution_index="0" special_mode_mask="0">
+      <ISPPreview>s5k4e8_snapshot</ISPPreview>
+      <ISPSnapshot>s5k4e8_snapshot</ISPSnapshot>
+      <ISPVideo>s5k4e8_video</ISPVideo>
+      <CPPPreview>s5k4e8_cpp_snapshot</CPPPreview>
+      <CPPSnapshot>s5k4e8_cpp_snapshot</CPPSnapshot>
+      <CPPLiveshot>s5k4e8_cpp_video</CPPLiveshot>
+      <CPPVideo>s5k4e8_cpp_video</CPPVideo>
+      <A3Preview>s5k4e8_zsl_preview</A3Preview>
+      <A3Video>s5k4e8_zsl_video</A3Video>
+    </ChromatixName>
+  </ResolutionChromatixInfo>
+</ChromatixConfigurationRoot>


### PR DESCRIPTION
Force selecting the right I2C speed on all cameras and make the
auxilliary camera available for regular snapshot and video (+zsl and such)
usecases.

Test OK: SDM630 Kirin DSDS.